### PR TITLE
feat: String decryption transformer

### DIFF
--- a/asm/src/main/kotlin/org/openrs2/asm/classpath/LibraryRemapper.kt
+++ b/asm/src/main/kotlin/org/openrs2/asm/classpath/LibraryRemapper.kt
@@ -58,6 +58,8 @@ public class LibraryRemapper(
 
     private fun extractFields() {
         for (clazz in classes.values) {
+            if (clazz.name.contains('/')) continue
+
             clazz.fields.removeIf { field ->
                 // do nothing if the field is not moved between classes
                 val oldOwner = remapper.mapType(clazz.name)
@@ -118,6 +120,8 @@ public class LibraryRemapper(
 
     private fun extractMethods() {
         for (clazz in classes.values) {
+            if (clazz.name.contains('/')) continue
+
             clazz.methods.removeIf { method ->
                 // do nothing if the method is not moved between classes
                 val oldOwner = remapper.mapType(clazz.name)

--- a/asm/src/main/kotlin/org/openrs2/asm/classpath/LibraryRemapper.kt
+++ b/asm/src/main/kotlin/org/openrs2/asm/classpath/LibraryRemapper.kt
@@ -58,7 +58,9 @@ public class LibraryRemapper(
 
     private fun extractFields() {
         for (clazz in classes.values) {
-            if (clazz.name.contains('/')) continue
+            if (clazz.name.contains('/')) {
+                continue
+            }
 
             clazz.fields.removeIf { field ->
                 // do nothing if the field is not moved between classes
@@ -120,7 +122,9 @@ public class LibraryRemapper(
 
     private fun extractMethods() {
         for (clazz in classes.values) {
-            if (clazz.name.contains('/')) continue
+            if (clazz.name.contains('/')) {
+                continue
+            }
 
             clazz.methods.removeIf { method ->
                 // do nothing if the method is not moved between classes

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticFieldUnscrambler.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticFieldUnscrambler.kt
@@ -30,6 +30,8 @@ public class StaticFieldUnscrambler(
             }
 
             for (clazz in library) {
+                if (clazz.name.contains('/')) continue
+
                 val clinit = clazz.methods.find { it.name == "<clinit>" }
                 val (simpleInitializers, complexInitializers) = clinit?.extractInitializers(clazz.name)
                     ?: Pair(emptyMap(), emptySet())

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticFieldUnscrambler.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticFieldUnscrambler.kt
@@ -30,7 +30,9 @@ public class StaticFieldUnscrambler(
             }
 
             for (clazz in library) {
-                if (clazz.name.contains('/')) continue
+                if (clazz.name.contains('/')) {
+                    continue
+                }
 
                 val clinit = clazz.methods.find { it.name == "<clinit>" }
                 val (simpleInitializers, complexInitializers) = clinit?.extractInitializers(clazz.name)

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticMethodUnscrambler.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticMethodUnscrambler.kt
@@ -24,6 +24,8 @@ public class StaticMethodUnscrambler(
             }
 
             for (clazz in library) {
+                if (clazz.name.contains('/')) continue
+
                 for (method in clazz.methods) {
                     if (method.access and Opcodes.ACC_STATIC == 0) {
                         continue

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticMethodUnscrambler.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/StaticMethodUnscrambler.kt
@@ -24,7 +24,9 @@ public class StaticMethodUnscrambler(
             }
 
             for (clazz in library) {
-                if (clazz.name.contains('/')) continue
+                if (clazz.name.contains('/')) {
+                    continue
+                }
 
                 for (method in clazz.methods) {
                     if (method.access and Opcodes.ACC_STATIC == 0) {

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/TypedRemapper.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/remap/TypedRemapper.kt
@@ -143,7 +143,8 @@ public class TypedRemapper private constructor(
 
         private fun verifyMapping(name: String, mappedName: String, maxObfuscatedNameLen: Int) {
             val originalName = StripClassNamePrefixRemapper.map(name)
-            if (originalName.length > maxObfuscatedNameLen && originalName != mappedName) {
+            val justThis = originalName.substringAfterLast('/')
+            if (justThis.length > maxObfuscatedNameLen && originalName != mappedName) {
                 logger.warn { "Remapping probably unobfuscated name $originalName to $mappedName" }
             }
         }

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
@@ -95,8 +95,6 @@ public class StringDecryptionTransformer : Transformer() {
                 // step 4: inline all string references to the static String[] field (specifically static!)
                 if (field != null) {
                     for (method in clazz.methods) {
-                        if (method.name == "<clinit>") continue
-
                         if (field.desc == "[Ljava/lang/String;") {
                             // multiple encrypted strings in the class so an array is produced
                             for (insn in method.instructions) {

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
@@ -1,0 +1,185 @@
+package org.openrs2.deob.bytecode.transform
+
+import com.github.michaelbull.logging.InlineLogger
+import jakarta.inject.Singleton
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.FieldInsnNode
+import org.objectweb.asm.tree.FieldNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.TableSwitchInsnNode
+import org.openrs2.asm.classpath.ClassPath
+import org.openrs2.asm.deleteExpression
+import org.openrs2.asm.intConstant
+import org.openrs2.asm.transform.Transformer
+
+@Singleton
+public class StringDecryptionTransformer : Transformer() {
+    private var stringsDecrypted = 0
+    private var classesDecrypted = 0
+    private var stringsInlined = 0
+
+    override fun preTransform(classPath: ClassPath) {
+        for (library in classPath.libraries) {
+            for (clazz in library) {
+                val clinit = clazz.methods.find { it.name == "<clinit>" } ?: continue
+
+                // step 1: identify the decryption methods
+                val inner = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
+                    .filter {
+                        it.owner == clazz.name && it.desc == "(Ljava/lang/String;)[C" &&
+                            it.next?.opcode == Opcodes.INVOKESTATIC
+                    }.firstOrNull()?.let {
+                        clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
+                    }
+                val outer = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
+                    .filter {
+                        it.owner == clazz.name && it.desc == "([C)Ljava/lang/String;" &&
+                            it.previous?.opcode == Opcodes.INVOKESTATIC
+                    }.firstOrNull()?.let {
+                        clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
+                    }
+
+                if (inner == null || outer == null) continue
+
+                // step 2: get the xor table from the outer method
+                val switch: TableSwitchInsnNode = outer.instructions.iterator().asSequence()
+                    .filterIsInstance<TableSwitchInsnNode>().firstOrNull() ?: continue
+
+                val xorLookup = ArrayList<Number>()
+                for (label in switch.labels) {
+                    xorLookup.add(label.next.intConstant ?: continue)
+                }
+                xorLookup.add(switch.dflt.next.intConstant ?: continue)
+
+                // step 3: decrypt all strings in the initializer
+                val strings = ArrayList<String>()
+                var field: FieldNode? = null
+                var fieldInit: AbstractInsnNode? = null
+                for (insn in clinit.instructions) {
+                    if (insn.opcode != Opcodes.INVOKESTATIC) continue
+                    val invoke = insn as MethodInsnNode
+                    if (invoke.owner != clazz.name || invoke.name != outer.name || invoke.desc != outer.desc) continue
+
+                    val ldc = invoke.previous.previous as LdcInsnNode
+                    val str = ldc.cst as String
+                    val decrypted = decryptString(str, xorLookup)
+
+                    ldc.cst = decrypted
+                    strings.add(decrypted)
+                    stringsDecrypted++
+
+                    if (field == null) {
+                        if (invoke.next?.opcode == Opcodes.AASTORE && invoke.next?.next?.opcode == Opcodes.PUTSTATIC) {
+                            // this one is the static String[] field
+                            val put = invoke.next.next as FieldInsnNode
+                            if (put.owner == clazz.name && put.desc == "[Ljava/lang/String;") {
+                                field = clazz.fields.find { it.name == put.name }
+                                fieldInit = put
+                            }
+                        } else if (invoke.next?.opcode == Opcodes.PUTSTATIC) {
+                            // this one is the static String field
+                            val put = invoke.next as FieldInsnNode
+                            if (put.owner == clazz.name && put.desc == "Ljava/lang/String;") {
+                                field = clazz.fields.find { it.name == put.name }
+                                fieldInit = put
+                            }
+                        }
+                    }
+
+                    clinit.instructions.remove(invoke.previous)
+                    clinit.instructions.remove(invoke)
+                }
+
+                // step 4: inline all string references to the static String[] field (specifically static!)
+                if (field != null) {
+                    for (method in clazz.methods) {
+                        if (method.name == "<clinit>") continue
+
+                        if (field.desc == "[Ljava/lang/String;") {
+                            // multiple encrypted strings in the class so an array is produced
+                            for (insn in method.instructions) {
+                                // we're looking for getstatic -> constant -> aaload
+                                // we start backwards (aaload) and check the previous 2 instructions
+                                if (insn.opcode != Opcodes.AALOAD) continue
+
+                                val push = insn.previous
+                                if (push.previous.opcode != Opcodes.GETSTATIC) continue
+
+                                val getstatic = push.previous as FieldInsnNode
+                                if (
+                                    getstatic.owner != clazz.name ||
+                                    getstatic.name != field.name ||
+                                    getstatic.desc != field.desc
+                                ) {
+                                    continue
+                                }
+
+                                val index = push.intConstant ?: continue
+                                val str = strings[index]
+                                val ldc = LdcInsnNode(str)
+
+                                method.instructions.remove(push)
+                                method.instructions.remove(insn)
+                                method.instructions.set(getstatic, ldc)
+
+                                stringsInlined++
+                            }
+                        } else if (field.desc == "Ljava/lang/String;") {
+                            // one encrypted string in the class so no array is produced
+                            for (insn in method.instructions) {
+                                if (insn.opcode != Opcodes.GETSTATIC) continue
+
+                                val getstatic = insn as FieldInsnNode
+                                if (
+                                    getstatic.owner != clazz.name ||
+                                    getstatic.name != field.name ||
+                                    getstatic.desc != field.desc
+                                ) {
+                                    continue
+                                }
+
+                                val str = strings[0]
+                                val ldc = LdcInsnNode(str)
+
+                                method.instructions.set(getstatic, ldc)
+
+                                stringsInlined++
+                            }
+                        }
+                    }
+
+                    // step 5: cleanup
+                    clazz.fields.remove(field)
+                    clinit.instructions.deleteExpression(fieldInit!!)
+                }
+
+                // step 5: cleanup
+                clazz.methods.remove(inner)
+                clazz.methods.remove(outer)
+
+                classesDecrypted++
+            }
+        }
+
+        if (stringsDecrypted > 0 || classesDecrypted > 0 || stringsInlined > 0) {
+            logger.info { "Decrypted $stringsDecrypted strings across $classesDecrypted classes" }
+            logger.info { "Inlined $stringsInlined string references" }
+        }
+    }
+
+    private fun decryptString(str: String, xorLookup: ArrayList<Number>): String {
+        val chars = str.toCharArray()
+        for (i in chars.indices) {
+            val xor = xorLookup[i % xorLookup.size]
+            chars[i] = (chars[i].code xor xor.toInt()).toChar()
+        }
+
+        return String(chars)
+    }
+
+    private companion object {
+        private val logger = InlineLogger()
+    }
+}

--- a/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
+++ b/deob-bytecode/src/main/kotlin/org/openrs2/deob/bytecode/transform/StringDecryptionTransformer.kt
@@ -4,14 +4,18 @@ import com.github.michaelbull.logging.InlineLogger
 import jakarta.inject.Singleton
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldInsnNode
 import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.LdcInsnNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.TableSwitchInsnNode
+import org.openrs2.asm.InsnMatcher
 import org.openrs2.asm.classpath.ClassPath
+import org.openrs2.asm.classpath.Library
 import org.openrs2.asm.deleteExpression
 import org.openrs2.asm.intConstant
+import org.openrs2.asm.nextReal
 import org.openrs2.asm.transform.Transformer
 
 @Singleton
@@ -20,158 +24,165 @@ public class StringDecryptionTransformer : Transformer() {
     private var classesDecrypted = 0
     private var stringsInlined = 0
 
-    override fun preTransform(classPath: ClassPath) {
-        for (library in classPath.libraries) {
-            for (clazz in library) {
-                val clinit = clazz.methods.find { it.name == "<clinit>" } ?: continue
+    override fun transformClass(classPath: ClassPath, library: Library, clazz: ClassNode): Boolean {
+        val clinit = clazz.methods.find { it.name == "<clinit>" } ?: return false
 
-                // step 1: identify the decryption methods
-                val inner = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
-                    .filter {
-                        it.owner == clazz.name && it.desc == "(Ljava/lang/String;)[C" &&
-                            it.next?.opcode == Opcodes.INVOKESTATIC
-                    }.firstOrNull()?.let {
-                        clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
-                    }
-                val outer = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
-                    .filter {
-                        it.owner == clazz.name && it.desc == "([C)Ljava/lang/String;" &&
-                            it.previous?.opcode == Opcodes.INVOKESTATIC
-                    }.firstOrNull()?.let {
-                        clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
-                    }
-
-                if (inner == null || outer == null) continue
-
-                // step 2: get the xor table from the outer method
-                val switch: TableSwitchInsnNode = outer.instructions.iterator().asSequence()
-                    .filterIsInstance<TableSwitchInsnNode>().firstOrNull() ?: continue
-
-                val xorLookup = ArrayList<Number>()
-                for (label in switch.labels) {
-                    xorLookup.add(label.next.intConstant ?: continue)
-                }
-                xorLookup.add(switch.dflt.next.intConstant ?: continue)
-
-                // step 3: decrypt all strings in the initializer
-                val strings = ArrayList<String>()
-                var field: FieldNode? = null
-                var fieldInit: AbstractInsnNode? = null
-                for (insn in clinit.instructions) {
-                    if (insn.opcode != Opcodes.INVOKESTATIC) continue
-                    val invoke = insn as MethodInsnNode
-                    if (invoke.owner != clazz.name || invoke.name != outer.name || invoke.desc != outer.desc) continue
-
-                    val ldc = invoke.previous.previous as LdcInsnNode
-                    val str = ldc.cst as String
-                    val decrypted = decryptString(str, xorLookup)
-
-                    ldc.cst = decrypted
-                    strings.add(decrypted)
-                    stringsDecrypted++
-
-                    if (field == null) {
-                        if (invoke.next?.opcode == Opcodes.AASTORE && invoke.next?.next?.opcode == Opcodes.PUTSTATIC) {
-                            // this one is the static String[] field
-                            val put = invoke.next.next as FieldInsnNode
-                            if (put.owner == clazz.name && put.desc == "[Ljava/lang/String;") {
-                                field = clazz.fields.find { it.name == put.name }
-                                fieldInit = put
-                            }
-                        } else if (invoke.next?.opcode == Opcodes.PUTSTATIC) {
-                            // this one is the static String field
-                            val put = invoke.next as FieldInsnNode
-                            if (put.owner == clazz.name && put.desc == "Ljava/lang/String;") {
-                                field = clazz.fields.find { it.name == put.name }
-                                fieldInit = put
-                            }
-                        }
-                    }
-
-                    clinit.instructions.remove(invoke.previous)
-                    clinit.instructions.remove(invoke)
-                }
-
-                // step 4: inline all string references to the static String[] field (specifically static!)
-                if (field != null) {
-                    for (method in clazz.methods) {
-                        if (field.desc == "[Ljava/lang/String;") {
-                            // multiple encrypted strings in the class so an array is produced
-                            for (insn in method.instructions) {
-                                // we're looking for getstatic -> constant -> aaload
-                                // we start backwards (aaload) and check the previous 2 instructions
-                                if (insn.opcode != Opcodes.AALOAD) continue
-
-                                val push = insn.previous
-                                if (push.previous.opcode != Opcodes.GETSTATIC) continue
-
-                                val getstatic = push.previous as FieldInsnNode
-                                if (
-                                    getstatic.owner != clazz.name ||
-                                    getstatic.name != field.name ||
-                                    getstatic.desc != field.desc
-                                ) {
-                                    continue
-                                }
-
-                                val index = push.intConstant ?: continue
-                                val str = strings[index]
-                                val ldc = LdcInsnNode(str)
-
-                                method.instructions.remove(push)
-                                method.instructions.remove(insn)
-                                method.instructions.set(getstatic, ldc)
-
-                                stringsInlined++
-                            }
-                        } else if (field.desc == "Ljava/lang/String;") {
-                            // one encrypted string in the class so no array is produced
-                            for (insn in method.instructions) {
-                                if (insn.opcode != Opcodes.GETSTATIC) continue
-
-                                val getstatic = insn as FieldInsnNode
-                                if (
-                                    getstatic.owner != clazz.name ||
-                                    getstatic.name != field.name ||
-                                    getstatic.desc != field.desc
-                                ) {
-                                    continue
-                                }
-
-                                val str = strings[0]
-                                val ldc = LdcInsnNode(str)
-
-                                method.instructions.set(getstatic, ldc)
-
-                                stringsInlined++
-                            }
-                        }
-                    }
-
-                    // step 5: cleanup
-                    clazz.fields.remove(field)
-                    clinit.instructions.deleteExpression(fieldInit!!)
-                }
-
-                // step 5: cleanup
-                clazz.methods.remove(inner)
-                clazz.methods.remove(outer)
-
-                classesDecrypted++
+        // step 1: identify the decryption methods
+        val inner = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
+            .filter {
+                it.owner == clazz.name && it.desc == "(Ljava/lang/String;)[C" &&
+                    it.next?.opcode == Opcodes.INVOKESTATIC
+            }.firstOrNull()?.let {
+                clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
             }
+        val outer = clinit.instructions.iterator().asSequence().filterIsInstance<MethodInsnNode>()
+            .filter {
+                it.owner == clazz.name && it.desc == "([C)Ljava/lang/String;" &&
+                    it.previous?.opcode == Opcodes.INVOKESTATIC
+            }.firstOrNull()?.let {
+                clazz.methods.find { method -> method.name == it.name && method.desc == it.desc }
+            }
+
+        if (inner == null || outer == null) return false
+
+        // step 2: get the xor table from the outer method
+        val switch = outer.instructions.iterator().asSequence()
+            .filterIsInstance<TableSwitchInsnNode>().firstOrNull() ?: return false
+
+        val key = mutableListOf<Int>()
+        for (label in switch.labels) {
+            key += label.nextReal?.intConstant ?: continue
+        }
+        key += switch.dflt.nextReal?.intConstant ?: return false
+
+        // step 3: decrypt all strings in the initializer
+        val strings = mutableListOf<String>()
+        var field: FieldNode? = null
+        var fieldInit: AbstractInsnNode? = null
+        for (insn in clinit.instructions) {
+            if (insn !is MethodInsnNode || insn.opcode != Opcodes.INVOKESTATIC) {
+                continue
+            }
+
+            if (insn.owner != clazz.name || insn.name != outer.name || insn.desc != outer.desc) {
+                continue
+            }
+
+            val ldc = insn.previous.previous as LdcInsnNode
+            val str = ldc.cst as String
+            val decrypted = decryptString(str, key)
+
+            ldc.cst = decrypted
+            strings.add(decrypted)
+            stringsDecrypted++
+
+            if (field == null) {
+                if (insn.next?.opcode == Opcodes.AASTORE && insn.next?.next?.opcode == Opcodes.PUTSTATIC) {
+                    // this one is the static String[] field
+                    val put = insn.next.next as FieldInsnNode
+                    if (put.owner == clazz.name && put.desc == "[Ljava/lang/String;") {
+                        field = clazz.fields.find { it.name == put.name }
+                        fieldInit = put
+                    }
+                } else if (insn.next?.opcode == Opcodes.PUTSTATIC) {
+                    // this one is the static String field
+                    val put = insn.next as FieldInsnNode
+                    if (put.owner == clazz.name && put.desc == "Ljava/lang/String;") {
+                        field = clazz.fields.find { it.name == put.name }
+                        fieldInit = put
+                    }
+                }
+            }
+
+            clinit.instructions.remove(insn.previous)
+            clinit.instructions.remove(insn)
         }
 
-        if (stringsDecrypted > 0 || classesDecrypted > 0 || stringsInlined > 0) {
-            logger.info { "Decrypted $stringsDecrypted strings across $classesDecrypted classes" }
-            logger.info { "Inlined $stringsInlined string references" }
+        // step 4: inline all string references to the static String[] field (specifically static!)
+        if (field != null) {
+            for (method in clazz.methods) {
+                if (field.desc == "[Ljava/lang/String;") {
+                    // multiple encrypted strings in the class so an array is produced
+                    for (insn in method.instructions) {
+                        // we're looking for getstatic -> constant -> aaload
+                        // we start backwards (aaload) and check the previous 2 instructions
+                        if (insn.opcode != Opcodes.AALOAD) {
+                            continue
+                        }
+
+                        val push = insn.previous
+                        if (push.previous.opcode != Opcodes.GETSTATIC) {
+                            continue
+                        }
+
+                        val getstatic = push.previous as FieldInsnNode
+                        if (
+                            getstatic.owner != clazz.name ||
+                            getstatic.name != field.name ||
+                            getstatic.desc != field.desc
+                        ) {
+                            continue
+                        }
+
+                        val index = push.intConstant ?: continue
+                        val str = strings[index]
+                        val ldc = LdcInsnNode(str)
+
+                        method.instructions.remove(push)
+                        method.instructions.remove(insn)
+                        method.instructions.set(getstatic, ldc)
+
+                        stringsInlined++
+                    }
+                } else if (field.desc == "Ljava/lang/String;") {
+                    // one encrypted string in the class so no array is produced
+                    for (insn in method.instructions) {
+                        if (insn.opcode != Opcodes.GETSTATIC) {
+                            continue
+                        }
+
+                        val getstatic = insn as FieldInsnNode
+                        if (
+                            getstatic.owner != clazz.name ||
+                            getstatic.name != field.name ||
+                            getstatic.desc != field.desc
+                        ) {
+                            continue
+                        }
+
+                        val str = strings[0]
+                        val ldc = LdcInsnNode(str)
+
+                        method.instructions.set(getstatic, ldc)
+
+                        stringsInlined++
+                    }
+                }
+            }
+
+            // step 5: cleanup
+            clazz.fields.remove(field)
+            clinit.instructions.deleteExpression(fieldInit!!)
         }
+
+        // step 5: cleanup
+        clazz.methods.remove(inner)
+        clazz.methods.remove(outer)
+
+        classesDecrypted++
+        return false
     }
 
-    private fun decryptString(str: String, xorLookup: ArrayList<Number>): String {
+    override fun postTransform(classPath: ClassPath) {
+        logger.info { "Decrypted $stringsDecrypted strings across $classesDecrypted classes" }
+        logger.info { "Inlined $stringsInlined string references" }
+    }
+
+    private fun decryptString(str: String, key: List<Int>): String {
         val chars = str.toCharArray()
         for (i in chars.indices) {
-            val xor = xorLookup[i % xorLookup.size]
-            chars[i] = (chars[i].code xor xor.toInt()).toChar()
+            val value = key[i % key.size]
+            chars[i] = (chars[i].code xor value).toChar()
         }
 
         return String(chars)


### PR DESCRIPTION
This was one of the main blockers to getting up to 667 deobfuscated. While there's some other changes to get the output compilable (that I think may be better suited as separate commits), this transformer seems to be at a good place to open a PR.

I also included some fixes around handling class scrambling inside packages -- I decided to go with the assumption that classes are *not* static-scrambled so they get skipped now.
The change in TypedRemapper is just to reduce the console warnings for packaged classes.
