### PR TITLE
Add postRead function so all config types can be implemented

### DIFF
--- a/cache/src/main/kotlin/org/openrs2/cache/config/ConfigType.kt
+++ b/cache/src/main/kotlin/org/openrs2/cache/config/ConfigType.kt
@@ -6,6 +6,7 @@ public abstract class ConfigType(
     public val id: Int
 ) {
     public abstract fun read(buf: ByteBuf, code: Int)
+    public open fun postRead() {}
     public abstract fun write(buf: ByteBuf)
 
     public fun read(buf: ByteBuf) {

--- a/cache/src/main/kotlin/org/openrs2/cache/config/ConfigTypeList.kt
+++ b/cache/src/main/kotlin/org/openrs2/cache/config/ConfigTypeList.kt
@@ -30,6 +30,7 @@ public abstract class ConfigTypeList<T : ConfigType>(
         cache.read(archive, group, file).use { buf ->
             type = allocate(id)
             type.read(buf)
+            type.postRead()
             types[id] = type
             return type
         }


### PR DESCRIPTION
Several configs, such as loc, flu, flo, require a postDecode function