### PR TITLE
feat: Paginated tables on archive website

### DIFF
--- a/archive/src/main/resources/org/openrs2/archive/static/css/openrs2.css
+++ b/archive/src/main/resources/org/openrs2/archive/static/css/openrs2.css
@@ -1,3 +1,7 @@
 html {
 	overflow-y: scroll;
 }
+
+#paginated-table {
+	display: none;
+}

--- a/archive/src/main/resources/org/openrs2/archive/static/js/openrs2.js
+++ b/archive/src/main/resources/org/openrs2/archive/static/js/openrs2.js
@@ -41,3 +41,9 @@ function buildSort(a, b) {
 	var bMinor = b[2] ? parseInt(b[2]) : 0;
 	return aMinor - bMinor;
 }
+
+$(function () {
+	$('#paginated-table').on('post-body.bs.table', function () {
+		$(this).fadeIn();
+	});
+})

--- a/archive/src/main/resources/org/openrs2/archive/templates/caches/index.html
+++ b/archive/src/main/resources/org/openrs2/archive/templates/caches/index.html
@@ -12,7 +12,7 @@
 		<main class="container">
 			<h1>Caches</h1>
 			<div class="table-responsive">
-				<table class="table table-striped table-bordered table-hover" data-toggle="table" data-filter-control="true" data-sticky-header="true" data-custom-sort="customSort">
+				<table id="paginated-table" class="table table-striped table-bordered table-hover" data-toggle="table" data-filter-control="true" data-sticky-header="true" data-custom-sort="customSort" data-pagination="true">
 					<thead class="table-dark">
 						<tr>
 							<th data-field="game" data-filter-control="select">Game</th>

--- a/archive/src/main/resources/org/openrs2/archive/templates/clients/index.html
+++ b/archive/src/main/resources/org/openrs2/archive/templates/clients/index.html
@@ -12,7 +12,7 @@
 		<main class="container">
 			<h1>Clients</h1>
 			<div class="table-responsive">
-				<table class="table table-striped table-bordered table-hover" data-toggle="table" data-filter-control="true" data-sticky-header="true" data-custom-sort="customSort">
+				<table id="paginated-table" class="table table-striped table-bordered table-hover" data-toggle="table" data-filter-control="true" data-sticky-header="true" data-custom-sort="customSort" data-pagination="true">
 					<thead class="table-dark">
 						<tr>
 							<th data-field="game" data-filter-control="select">Game</th>


### PR DESCRIPTION
Thanks to Riley on Rune-Server for this simple fix earlier this year, I just applied it to the clients page as well and put it in a PR. Scope is intentionally kept small to avoid investing much time in reworking the frontend with more robust frameworks.

I consider this to be a reasonable priority - the page load speed is growing to be near-unusable with 5-20 second times for anyone who regularly uses the archive site and navigates back and forth. The backend is not the problem, just the table touching the DOM, evident as caches.json is generated instantly.

PR consists of enabling pagination in the table library + adding a visual fade-in for UX.

## Caches

https://github.com/user-attachments/assets/2aa5eb1b-e50e-4815-be69-0c453a5f16ec

There's a significant amount of lag. Notice that it needs more time after visually loading for the sorting to initialize, and the sorting is giving me input troubles (I'm not pressing backspace).

---

https://github.com/user-attachments/assets/7faafd42-46a5-47fd-b006-76e30a570fb7

## Clients

https://github.com/user-attachments/assets/bb83933e-c2c2-476f-a65d-0b3bcc8fe20a

Same loading/input problems as the caches page.

---

https://github.com/user-attachments/assets/17824c56-61b2-47d3-8291-931d5534e8aa