### PR TITLE
Improve Identity transformer

### DIFF
--- a/deob-ast/src/main/kotlin/org/openrs2/deob/ast/transform/IdentityTransformer.kt
+++ b/deob-ast/src/main/kotlin/org/openrs2/deob/ast/transform/IdentityTransformer.kt
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt
 import jakarta.inject.Singleton
 import org.openrs2.deob.ast.Library
 import org.openrs2.deob.ast.LibraryGroup
+import org.openrs2.deob.ast.util.findAll
 import org.openrs2.deob.ast.util.walk
 
 @Singleton
@@ -59,19 +60,15 @@ public class IdentityTransformer : Transformer() {
             }
         }
 
-        unit.walk { expr: AssignExpr ->
-            val identity = when (expr.operator) {
+        unit.findAll { expr: AssignExpr ->
+            when (expr.operator) {
                 // x += 0, x -= 0
                 AssignExpr.Operator.PLUS, AssignExpr.Operator.MINUS -> expr.value.isZero()
                 // x *= 1, x /= 1
                 AssignExpr.Operator.MULTIPLY, AssignExpr.Operator.DIVIDE -> expr.value.isOne()
                 else -> false
             }
-
-            if (!identity) {
-                return@walk
-            }
-
+        }.forEach { expr ->
             expr.parentNode.ifPresent { parent ->
                 if (parent is ExpressionStmt) {
                     parent.remove()

--- a/deob-ast/src/main/kotlin/org/openrs2/deob/ast/transform/IdentityTransformer.kt
+++ b/deob-ast/src/main/kotlin/org/openrs2/deob/ast/transform/IdentityTransformer.kt
@@ -3,6 +3,7 @@ package org.openrs2.deob.ast.transform
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.expr.AssignExpr
 import com.github.javaparser.ast.expr.BinaryExpr
+import com.github.javaparser.ast.expr.BooleanLiteralExpr
 import com.github.javaparser.ast.expr.Expression
 import com.github.javaparser.ast.expr.IntegerLiteralExpr
 import com.github.javaparser.ast.expr.LongLiteralExpr
@@ -56,6 +57,26 @@ public class IdentityTransformer : Transformer() {
                     }
                 }
 
+                BinaryExpr.Operator.BINARY_AND -> {
+                    if (expr.right.isTrue()) {
+                        // x & true
+                        expr.replace(expr.left)
+                    } else if (expr.left.isTrue()) {
+                        // true & x
+                        expr.replace(expr.right)
+                    }
+                }
+
+                BinaryExpr.Operator.BINARY_OR -> {
+                    if (expr.right.isFalse()) {
+                        // x | false
+                        expr.replace(expr.left)
+                    } else if (expr.left.isFalse()) {
+                        // false | x
+                        expr.replace(expr.right)
+                    }
+                }
+
                 else -> Unit
             }
         }
@@ -66,6 +87,10 @@ public class IdentityTransformer : Transformer() {
                 AssignExpr.Operator.PLUS, AssignExpr.Operator.MINUS -> expr.value.isZero()
                 // x *= 1, x /= 1
                 AssignExpr.Operator.MULTIPLY, AssignExpr.Operator.DIVIDE -> expr.value.isOne()
+                // x &= true
+                AssignExpr.Operator.BINARY_AND -> expr.value.isTrue()
+                // x |= false
+                AssignExpr.Operator.BINARY_OR -> expr.value.isFalse()
                 else -> false
             }
         }.forEach { expr ->
@@ -93,5 +118,13 @@ public class IdentityTransformer : Transformer() {
             is LongLiteralExpr -> asNumber() == 1L
             else -> false
         }
+    }
+
+    private fun Expression.isTrue(): Boolean {
+        return (this is BooleanLiteralExpr) && value
+    }
+
+    private fun Expression.isFalse(): Boolean {
+        return (this is BooleanLiteralExpr) && !value
     }
 }

--- a/deob-ast/src/main/kotlin/org/openrs2/deob/ast/util/NodeUtils.kt
+++ b/deob-ast/src/main/kotlin/org/openrs2/deob/ast/util/NodeUtils.kt
@@ -2,6 +2,10 @@ package org.openrs2.deob.ast.util
 
 import com.github.javaparser.ast.Node
 
+public inline fun <reified T : Node> Node.findAll(noinline predicate: (T) -> Boolean): List<T> {
+    return findAll(T::class.java, predicate)
+}
+
 public inline fun <reified T : Node> Node.walk(crossinline consumer: (T) -> Unit) {
     this.walk(Node.TreeTraversal.POSTORDER) {
         if (it is T) {


### PR DESCRIPTION
Fixes an issue in `IdentityTransformer`, caused by removing Nodes while walking the tree (which is implied to not be permitted [here](https://javaparser.org/functional-tree-traversal), and Javaparser's traversal code makes no attempt at supporting it).

A separate commit adds support for removing the boolean identities (`x & true`, `x | false`).