### PR TITLE
Fix Archive#capacity returning the same result

### DIFF
--- a/cache/src/main/kotlin/org/openrs2/cache/Archive.kt
+++ b/cache/src/main/kotlin/org/openrs2/cache/Archive.kt
@@ -116,7 +116,7 @@ public abstract class Archive internal constructor(
 
     // TODO(gpe): rename/move, reindex, rekey, method to go from name->id
 
-    public val capacity: Int = index.capacity
+    public val capacity: Int get() = index.capacity
 
     public fun capacity(group: Int): Int {
         val entry = index[group] ?: throw FileNotFoundException()


### PR DESCRIPTION
`Cache#capacity(archive)` (which calls `Archive#capacity`) was returning the same result even after writing more groups to it due to the property being set when the archive was initialized instead of using a getter that would access the current value from the index.